### PR TITLE
Fix generated path error.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -77,8 +77,9 @@ const plugin = ({ omitInputs = [], manifestName = MANIFEST_NAME }: ManifestPlugi
 				}
 			}
 
-			mkdirSync(config.build.outDir, { recursive: true });
-			writeFileSync(path.resolve(config.build.outDir, `${manifestName}.json`), JSON.stringify(manifest, null, '\t'));
+			const outputDir = path.resolve(config.root, config.build.outDir);
+			mkdirSync(outputDir, { recursive: true });
+			writeFileSync(path.resolve(outputDir, `${manifestName}.json`), JSON.stringify(manifest, null, '\t'));
 		});
 	},
 });


### PR DESCRIPTION
As offical document, `build.outDir` is path relative of root, not `cwd`, so before we write file, we should resolve this path to make sure we can run it in anywhere.

I have pass test in my local copy of this plugin.

Reference: 
- https://vitejs.dev/config/build-options.html#build-outdir
- https://vitejs.dev/guide/#index-html-and-project-root