### PR TITLE
Update peer dependency range to target Vite 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-dev-manifest",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Vite plugin for generating manifest during dev server",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
@@ -41,6 +41,6 @@
     "vite": "^4.0.0"
   },
   "peerDependencies": {
-    "vite": "^2.7.0 || ^3.0.0 || ^4.0.0"
+    "vite": "^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0" 
   }
 }


### PR DESCRIPTION
Adjusts the peer dependency range to target Vite 5.


I am unsure what else would need to be changed for this plugin in  to support Vite 5. However I did  test this change  locally with a Vite 5  build and had  no obvious issues.
